### PR TITLE
Handle numeric directories

### DIFF
--- a/powerls.psm1
+++ b/powerls.psm1
@@ -19,7 +19,7 @@
 #>
 function PowerLS {
   param(
-    $redirect = "."
+    [string]$redirect = "."
   )
     write-host "" # add newline at top
 


### PR DESCRIPTION
Powerls gives an error if you attempt to do a listing of a numeric folder, such as `powerls 2015`. This fixes that issue by specifying the type of the `$redirect` parameter to be a string.
